### PR TITLE
Removed thousands separator in money formatting

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -39,7 +39,7 @@ class Money
      */
     private function format()
     {
-        return number_format(($this->value / 100), 2);
+        return number_format(($this->value / 100), 2, '.', '');
     }
 
     /**


### PR DESCRIPTION
Thousands separator causes errors for amounts over $1000.00.
